### PR TITLE
The Navigation router + Parcel RSC Example

### DIFF
--- a/examples/navigation-parcel/App.tsx
+++ b/examples/navigation-parcel/App.tsx
@@ -1,0 +1,29 @@
+'use server-entry';
+import "./client";
+import React from "react";
+import { SceneView } from "navigation-react";
+import RootProvider from "./RootProvider";
+const People = React.lazy(() => import("./People"));
+const Person = React.lazy(() => import("./Person"));
+
+const App = async ({url}: any) => {
+  return (
+    <html>
+      <head>
+        <title>Navigation Parcel</title>
+      </head>
+      <body>
+        <RootProvider url={url}>
+          <SceneView active="people">
+            <People />
+          </SceneView>
+          <SceneView active="person" dataKeyDeps={['id']}>
+            <Person />
+          </SceneView>
+        </RootProvider>
+      </body>
+    </html>
+  );
+}
+
+export default App;

--- a/examples/navigation-parcel/Filter.tsx
+++ b/examples/navigation-parcel/Filter.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { startTransition } from 'react';
+import { RefreshLink, useNavigationEvent } from 'navigation-react';
+import { useOptimistic } from 'react';
+
+const Filter = () => {
+    const {data, stateNavigator} = useNavigationEvent();
+    const {name} = data;
+    const [optimisticName, setOptimisticName] = useOptimistic(name || '', (_, newName) => newName);
+    return (
+        <div>
+            <div>
+                <label htmlFor="name">Name</label>
+                <input id="name" value={optimisticName} onChange={({target: {value}}) => {
+                    startTransition(() => {
+                        setOptimisticName(value);
+                        stateNavigator.refresh({...data, name: value, page: null});
+                    });
+                }} />
+            </div>
+            Page size
+            <RefreshLink navigationData={{size: 5, page: null}} includeCurrentData>5</RefreshLink>
+            <RefreshLink navigationData={{size: 10, page: null}} includeCurrentData>10</RefreshLink>
+        </div>
+    );
+}
+
+export default Filter;

--- a/examples/navigation-parcel/Friends.tsx
+++ b/examples/navigation-parcel/Friends.tsx
@@ -1,0 +1,26 @@
+'use server-entry'
+import { RefreshLink, useNavigationEvent } from 'navigation-react';
+import { getFriends } from './data';
+import Gender from './Gender';
+
+const Friends = async () => {
+  const {data: {show, id, gender}} = useNavigationEvent();
+  const friends = await getFriends(id, gender);
+  return (
+    <>
+      <RefreshLink navigationData={{show: !show}} includeCurrentData>{`${!show ? 'Show' : 'Hide'} Friends`}</RefreshLink>
+      {show && (
+        <>
+          <Gender />
+          <ul>
+            {friends.map(({id, name}) => (
+              <li key={id}><RefreshLink navigationData={{id}} includeCurrentData>{name}</RefreshLink></li>
+            ))}
+          </ul>
+        </>
+      )}
+    </>
+  );
+}
+
+export default Friends;

--- a/examples/navigation-parcel/Gender.tsx
+++ b/examples/navigation-parcel/Gender.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { startTransition } from 'react';
+import { useNavigationEvent } from 'navigation-react';
+import { useOptimistic } from 'react';
+
+const Gender = () => {
+    const {data, stateNavigator} = useNavigationEvent();
+    const {gender} = data;
+    const [optimisticGender, setOptimisticGender] = useOptimistic(gender || '', (_, newGender) => newGender);
+    return (
+        <div>
+            <label htmlFor="gender">Gender</label>
+            <select id="gender" value={optimisticGender} onChange={({target: {value}}) => {
+                startTransition(() => {
+                    setOptimisticGender(value);
+                    stateNavigator.refresh({...data, gender: value});
+                });
+            }}>
+                <option value=""></option>
+                <option value="male">Male</option>
+                <option value="female">Female</option>
+                <option value="other">Other</option>
+            </select>
+        </div>
+    );
+}
+
+export default Gender;

--- a/examples/navigation-parcel/Pager.tsx
+++ b/examples/navigation-parcel/Pager.tsx
@@ -1,0 +1,26 @@
+import { RefreshLink, useNavigationEvent } from 'navigation-react';
+
+const Pager = ({totalRowCount}: {totalRowCount: number}) => {
+  const {data: {page, size} } = useNavigationEvent();
+  const lastPage = Math.ceil(totalRowCount / size);
+  return (
+    <div>
+      <ul>
+        {totalRowCount ?
+          <>
+            <li><RefreshLink navigationData={{page: 1}} includeCurrentData disableActive>First</RefreshLink></li>
+            <li><RefreshLink navigationData={{page: Math.max(page - 1, 1)}} includeCurrentData disableActive>Previous</RefreshLink></li>
+            <li><RefreshLink navigationData={{page: Math.min(lastPage, page + 1)}} includeCurrentData disableActive>Next</RefreshLink></li>
+            <li><RefreshLink navigationData={{page: lastPage}} includeCurrentData disableActive>Last</RefreshLink></li>
+          </> :
+          <>
+            <li>First</li><li>Previous</li><li>Next</li><li>Last</li>
+          </>
+        }
+      </ul>
+      Total Count {totalRowCount}
+    </div>
+  );
+}
+
+export default Pager;

--- a/examples/navigation-parcel/People.tsx
+++ b/examples/navigation-parcel/People.tsx
@@ -1,0 +1,39 @@
+'use server-entry'
+import { searchPeople } from './data';
+import { NavigationLink, RefreshLink, useNavigationEvent } from 'navigation-react';
+import Filter from './Filter';
+import Pager from './Pager';
+
+const People = async () => {
+  const {data: {name, page, size, sort}} = useNavigationEvent();
+  const {people, count} = await searchPeople(name, page, size, sort);
+  return (
+    <>
+      <h1>People</h1>
+      <Filter />
+      <table>
+        <thead>
+          <tr>
+            <th>
+              <RefreshLink navigationData={{sort: sort === 'asc' ? 'desc' : 'asc'}} includeCurrentData>Name</RefreshLink>
+            </th>
+            <th>Date of Birth</th>
+          </tr>
+        </thead>
+        <tbody>
+          {people.map(({id, name, dateOfBirth}) => (
+            <tr key={id}>
+              <td>
+                <NavigationLink stateKey="person" navigationData={{id: id}}>{name}</NavigationLink>
+              </td>
+              <td>{dateOfBirth}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Pager totalRowCount={count} />
+    </>
+  );
+}
+
+export default People;

--- a/examples/navigation-parcel/Person.tsx
+++ b/examples/navigation-parcel/Person.tsx
@@ -1,0 +1,31 @@
+'use server-entry'
+import { getPerson } from './data';
+import { SceneView, NavigationBackLink, useNavigationEvent } from 'navigation-react';
+import Friends from "./Friends";
+
+const Person = async () => {
+  const {data} = useNavigationEvent();
+  const {name, dateOfBirth, email, phone} = await getPerson(data.id);
+  return (
+    <>
+      <h1>Person</h1>
+      <div>
+        <NavigationBackLink distance={1}>Person Search</NavigationBackLink>
+        <div>
+          <h2>{name}</h2>
+          <div>Date of Birth</div>
+          <div>{dateOfBirth}</div>
+          <div>Email</div>
+          <div>{email}</div>
+          <div>Phone</div>
+          <div>{phone}</div>
+        </div>
+        <SceneView active="person" name="friends">
+          <Friends />
+        </SceneView>
+      </div>
+    </>
+  )
+}
+
+export default Person;

--- a/examples/navigation-parcel/README.md
+++ b/examples/navigation-parcel/README.md
@@ -1,0 +1,9 @@
+# The Navigation router + Parcel RSC Example
+
+This example shows [the Navigation router](https://github.com/grahammendick/navigation)'s RSC support using Parcel. It's a master/details example. The first scene is a list of 'People' and the second scene is the details of a selected 'Person'. 
+
+The Navigation router uses Parcel's RSC support to SSR the first scene. Only the People bundle is downloaded when the example first loads.
+
+On link clicks, the Navigation router uses Parcel's client RSC fetch to only update the content that's changed. When clicking 'Show Friends' on the Person Scene, for example, the Navigation router only fetches the Friends list and not the unchanged Person's details.
+
+The React community has a skewed view of RSC's because they think it has to look like Next.js. But this example shows how simple RSC apps can be. There's no file-based routing, no layout files, no parallel routes. It looks just like a normal React SPA from the pre-RSC days.

--- a/examples/navigation-parcel/RootProvider.tsx
+++ b/examples/navigation-parcel/RootProvider.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { useMemo } from "react";
+import { fetchRSC } from '@parcel/rsc/client';
+import { StateNavigator, HTML5HistoryManager } from 'navigation';
+import { NavigationHandler } from "navigation-react";
+import stateNavigator from "./stateNavigator";
+
+const NavigationProvider = ({url, children}: any) => {
+  const navigator = useMemo(() => {
+    const navigator = new StateNavigator(stateNavigator, new HTML5HistoryManager());
+    navigator.navigateLink(url);
+    return navigator;
+  }, []);
+  return (
+    <NavigationHandler stateNavigator={navigator} fetchRSC={fetchRSC}>
+      {children}
+    </NavigationHandler>
+  )
+}
+
+export default NavigationProvider;

--- a/examples/navigation-parcel/client.tsx
+++ b/examples/navigation-parcel/client.tsx
@@ -1,0 +1,4 @@
+'use client-entry';
+import {hydrate} from '@parcel/rsc/client';
+
+hydrate();

--- a/examples/navigation-parcel/data.ts
+++ b/examples/navigation-parcel/data.ts
@@ -1,0 +1,54 @@
+type Person = {id: number, name: string, gender: 'male' | 'female' | 'other', dateOfBirth: string, email: string, phone: string, friends: number[]};
+
+var people: Person[] = [
+    {id: 1, name: 'Bell Halvorson', gender: 'female', dateOfBirth: '01/01/1980', email: 'bell@navigation.com', phone: '555 0001', friends: [2,3,4,5]},
+    {id: 2, name: 'Aditya Larson', gender: 'male', dateOfBirth: '01/02/1980', email: 'aditya@navigation.com', phone: '555 0002', friends: [3,4,5,6]},
+    {id: 3, name: 'Rashawn Schamberger', gender: 'male', dateOfBirth: '01/03/1980', email: 'rashawn@navigation.com', phone: '555 0003', friends: [4,5,6,7]},
+    {id: 4, name: 'Rupert Grant', gender: 'male', dateOfBirth: '01/04/1980', email: 'rupert@navigation.com', phone: '555 0004', friends: [5,6,7,8]},
+    {id: 5, name: 'Opal Carter', gender: 'female', dateOfBirth: '01/05/1980', email: 'opal@navigation.com', phone: '555 0005', friends: [6,7,8,9]},
+    {id: 6, name: 'Candida Christiansen', gender: 'female', dateOfBirth: '01/06/1980', email: 'candida@navigation.com', phone: '555 0006', friends: [7,8,9,10]},
+    {id: 7, name: 'Haven Stroman', gender: 'other', dateOfBirth: '01/07/1980', email: 'haven@navigation.com', phone: '555 0007', friends: [8,9,10,11]},
+    {id: 8, name: 'Celine Leannon', gender: 'female', dateOfBirth: '01/08/1980', email: 'celine@navigation.com', phone: '555 0008', friends: [9,10,11,12]},
+    {id: 9, name: 'Ryan Ruecker', gender: 'male', dateOfBirth: '01/09/1980', email: 'ryan@navigation.com', phone: '555 0009', friends: [10,11,12,1]},
+    {id: 10, name: 'Kaci Hoppe', gender: 'other', dateOfBirth: '01/10/1980', email: 'kaci@navigation.com', phone: '555 0010', friends: [11,12,1,2]},
+    {id: 11, name: 'Fernando Dietrich', gender: 'male', dateOfBirth: '01/11/1980', email: 'fernando@navigation.com', phone: '555 0011', friends: [12,1,2,3]},
+    {id: 12, name: 'Emelie Lueilwitz', gender: 'female', dateOfBirth: '01/12/1980', email: 'emelie@navigation.com', phone: '555 0012', friends: [1,2,3,4]}
+];
+
+const searchPeople = async (name: string, pageNumber: number, pageSize: number, sortExpression: string) => {
+    return new Promise((res: ((data: {people: Person[], count: number}) => void)) => {
+        var start = (pageNumber - 1) * pageSize;
+        var filteredPeople = people.sort((personA, personB) => {
+            var mult = sortExpression.indexOf('desc') === -1 ? -1 : 1;
+            return mult * (personA.name < personB.name ? 1 : -1);
+        }).filter(person => !name || person.name.toUpperCase().indexOf(name.toUpperCase()) !== -1)
+        setTimeout(() => {
+            res({
+                people: filteredPeople.slice(start, start + pageSize),
+                count: filteredPeople.length
+            });
+        }, 10);
+    })
+};
+
+const getPerson = async (id: number) => {
+    return new Promise((res: ((person: Person) => void)) => {
+        const person = people.find(({id: personId}) => personId === id)!
+        setTimeout(() => {
+            res(person);
+        }, 10);
+    })
+}
+
+const getFriends = async (id: number, gender: 'male' | 'female' | 'other') => {
+    return new Promise((res: ((friends: Person[]) => void)) => {
+        const person = people.find(({id: personId}) => personId == id)!
+        setTimeout(() => {
+            res(person.friends.map((id) => (
+                people.find(({id: personId}) => personId === id)!
+            )).filter(({gender: personGender}) => !gender || personGender === gender));
+        }, 10);
+    })
+}
+
+export {searchPeople, getPerson, getFriends};

--- a/examples/navigation-parcel/package.json
+++ b/examples/navigation-parcel/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "navigation-parcel",
+  "description": "",
+  "version": "1.0.0",
+  "source": "server.tsx",
+  "server": "dist/server.js",
+  "targets": {
+    "server": {
+      "context": "react-server",
+      "includeNodeModules": {
+        "express": false
+      }
+    }
+  },
+  "scripts": {
+    "build": "rm -rf ../../.parcel-cache && rm -rf dist && parcel build --no-cache",
+    "start": "parcel"
+  },
+  "dependencies": {
+    "@parcel/rsc": "canary",
+    "express": "^4.18.2",
+    "navigation": "^6.2.0",
+    "navigation-react": "4.5.1-rsc.0",
+    "react": "canary",
+    "react-dom": "canary"
+  }
+}

--- a/examples/navigation-parcel/package.json
+++ b/examples/navigation-parcel/package.json
@@ -20,7 +20,7 @@
     "@parcel/rsc": "canary",
     "express": "^4.18.2",
     "navigation": "^6.2.0",
-    "navigation-react": "4.5.1-rsc.0",
+    "navigation-react": "^4.5.1-rsc.1",
     "react": "canary",
     "react-dom": "canary"
   }

--- a/examples/navigation-parcel/server.tsx
+++ b/examples/navigation-parcel/server.tsx
@@ -1,0 +1,51 @@
+import express from 'express';
+import { renderRequest, renderRSC } from '@parcel/rsc/node';
+import { StateNavigator } from 'navigation';
+import { NavigationHandler } from 'navigation-react';
+import stateNavigator from './stateNavigator';
+import App from './App';
+import Person from './Person';
+import People from './People';
+import Friends from './Friends';
+
+const app = express();
+
+app.use(express.static('dist'));
+app.use(express.json());
+
+app.get('/favicon.ico', function (req, res) {
+  res.statusCode = 404;
+  res.end();
+});
+
+app.get('*', async (req, res) => {
+  const navigator = new StateNavigator(stateNavigator);
+  navigator.navigateLink(req.url);
+  await renderRequest(req, res, (
+    <NavigationHandler stateNavigator={navigator}>
+      <App url={req.url} />
+    </NavigationHandler>
+  ), {component: App});
+});
+
+app.post('*', async (req, res) => {
+  const sceneViews: any = {
+    people: People,
+    person: Person,
+    friends: Friends
+  };
+  const View = sceneViews[req.body.sceneViewKey];
+  const navigator = new StateNavigator(stateNavigator);
+  navigator.navigateLink(req.body.oldUrl);
+  navigator.navigateLink(req.url);
+  const stream = renderRSC(
+    <NavigationHandler stateNavigator={navigator}>
+      <View />
+    </NavigationHandler>
+  );
+  res.set('Content-Type', 'text/x-component');
+  stream.pipe(res);
+});
+
+app.listen(3001);
+console.log('Server listening on port 3001');

--- a/examples/navigation-parcel/stateNavigator.ts
+++ b/examples/navigation-parcel/stateNavigator.ts
@@ -1,0 +1,8 @@
+import { StateNavigator } from 'navigation';
+
+const stateNavigator = new StateNavigator([
+  {key: 'people', route: '{page?}', defaults: {page: 1, sort: 'asc', size: 10}},
+  {key: 'person', route: 'person/{id}+/{show}', defaults: {id: 0, show: false}, trackCrumbTrail: true}
+]);
+
+export default stateNavigator;


### PR DESCRIPTION
I'm not expecting you to merge this PR but I thought making one would be the best way to show how beautiful RSC's look when [the Navigation router](https://github.com/grahammendick/navigation) and Parcel get together. It's a master/details example that you can run, like the other examples, using `npm run build`. The first scene is a list of people and the second scene shows an individual person. 

Thank you for adding RSC support to Parcel 🙏. Extra special thanks for this amazing repo. I really wanted to get into RSC's but kept running into a brick wall. Then I stumbled upon these examples. Why don't you rename the repo to TodoRSC? It might encourage the other bundlers to show off their own implementations like TodoMVC once did.

The Navigation router and Parcel show that you can have all the power of RSC's without having to bend your App into the shape of Next.js. The example in this PR looks just the same as a React SPA from the pre-RSC days. And yet it has all the power of RSC's - SSR, no waterfalls, automatic code splitting, colocated data fetch. What's more, the Navigation router only fetches the content that's changed.

